### PR TITLE
zett no longer replaced by alepha when game ends

### DIFF
--- a/src/style/app.css
+++ b/src/style/app.css
@@ -939,6 +939,7 @@ ul li {
   right: 96px;
   width: 128px;
   height: 128px;
+  background-position: 0 -768px;
 }
 
 .zettIdle {


### PR DESCRIPTION
- changes background position of keyframe to stay on Lord Zett upon game end

resolves #278